### PR TITLE
some small edits: but mostly a fix to keep bundle working under Mavericks

### DIFF
--- a/Commands/Align Source.tmCommand
+++ b/Commands/Align Source.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -W0
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
 
 require 'yaml'
 

--- a/Commands/Align Source.tmCommand
+++ b/Commands/Align Source.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-
+	<string>#!/usr/bin/env ruby18
 require 'yaml'
 
 MINIMUM_SPACING_BEFORE = "minimum_spacing_before"

--- a/Preferences/Alignment Patterns (ObjC).tmPreferences
+++ b/Preferences/Alignment Patterns (ObjC).tmPreferences
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>Alignment Patterns (R)</string>
+	<string>Alignment Patterns (Objective C)</string>
 	<key>scope</key>
-	<string>source.r</string>
+	<string>source.c</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>
@@ -17,14 +17,14 @@
 				<string>[
       { 
         "comment" : "align on assignments",
-        "regexp" : "=|&lt;-|-&gt;",
+        "regexp" : "=",
         "minimum_spacing_before" : " ", 
         "minimum_spacing_after" : " ",
         "padding" : "before"
       },
       { 
-        "comment" : "align right-hand side formulae assignments",
-        "regexp" : "~",
+        "comment" : "method",
+        "regexp" : ":",
         "minimum_spacing_before" : " ", 
         "minimum_spacing_after" : " ",
         "padding" : "before"
@@ -47,6 +47,6 @@
 		</array>
 	</dict>
 	<key>uuid</key>
-	<string>B020B97F-EC78-4EC1-AFF3-01CF528980CD</string>
+	<string>F1170F79-D3BD-4E65-9392-72AD0815A532</string>
 </dict>
 </plist>

--- a/Preferences/Alignment Patterns (R).tmPreferences
+++ b/Preferences/Alignment Patterns (R).tmPreferences
@@ -25,16 +25,22 @@
       { 
         "comment" : "align right-hand side formulae assignments",
         "regexp" : "~",
+        "minimum_spacing_before" : " ", 
+        "minimum_spacing_after" : " ",
         "padding" : "before"
       },
       { 
         "comment" : "align amy stacked asignments on a line",
         "regexp" : ";",
+        "minimum_spacing_before" : "", 
+        "minimum_spacing_after" : " ",
         "padding" : "before"
       },
       {
         "comment" : "align any comments",
         "regexp" : "#", 
+        "minimum_spacing_before" : " ", 
+        "minimum_spacing_after" : " ",
         "padding" : "before"
       }]</string>
 			</dict>

--- a/Preferences/Alignment Patterns (graphviz).tmPreferences
+++ b/Preferences/Alignment Patterns (graphviz).tmPreferences
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Alignment Patterns (graphviz)</string>
+	<key>scope</key>
+	<string>source.dot</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_SOURCE_ALIGNMENT_PATTERN</string>
+				<key>value</key>
+				<string>[
+      { 
+        "comment" : "align on [",
+        "regexp" : "\[",
+        "minimum_spacing_before" : " ", 
+        "minimum_spacing_after" : " ",
+        "padding" : "before"
+      },
+      { 
+        "comment" : "align arrows",
+        "regexp" : "-&gt;",
+        "minimum_spacing_before" : " ", 
+        "minimum_spacing_after" : " ",
+        "padding" : "before"
+      },
+      { 
+        "comment" : "align amy asignments",
+        "regexp" : "=",
+        "minimum_spacing_before" : "", 
+        "minimum_spacing_after" : " ",
+        "padding" : "before"
+      },
+      {
+        "comment" : "align any comments",
+        "regexp" : "#", 
+        "minimum_spacing_before" : " ", 
+        "minimum_spacing_after" : " ",
+        "padding" : "before"
+      }]</string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>7912553A-A897-4666-9F38-D067996ED4CC</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -23,23 +23,24 @@ the following as content for the setting:
         { name = 'TM_SOURCE_ALIGNMENT_PATTERN';
           value = '[
           { 
-            "regexp" : "=>", 
-            "spacing" : "before"
+            "regexp" : "=", 
+            "padding" : "before"
           },
           { 
             "regexp" : ":", 
-            "spacing" : "after"
+            "padding" : "after"
           }]';
         },
       );
     }
 
-`value` is a JSON array containing a list of `regexp` and `spacing` properties. 
+`value` is a JSON array containing a list of `regexp` and `padding` properties. 
+
+This example contains two alignment targets: `=` and `:`
 
 `regexp` is a regular expression which will capture your alignment string. It could be as simple as "=".
 
-`spacing` can be set to `before` or `after` depending on whether you to insert the padding spaces
-before or after the alignment string.
+`padding` can be set to `before` or `after` depending on whether you to insert the padding spaces before or after the alignment string.
 
 ### Advanced
 


### PR DESCRIPTION
65be771 forces Ruby 1,8

bcbb301 adds alignment support for GraphViz documents

09e558c alters the spacing for R (to pad = with space)
